### PR TITLE
Added scope organization param into MCP URL to allow specific organizations 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,0 @@
-# API Configuration
-API_URL=https://api.cloud.portaljs.com
-
-# Optional: Add API key if required for authenticated operations
-# API_KEY=your-api-key-here

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,6 @@ or be default URL if not presented with the org name in the mcp url
 */
 let CURRENT_API_URL = "https://api.cloud.portaljs.com";
 
-// Define our MCP agent with tools
 export class MyMCP extends McpAgent {
 	server = new McpServer({
 		name: "PortalJS MCP Server",
@@ -182,7 +181,6 @@ export class MyMCP extends McpAgent {
 				limit: z.number().optional().default(10).describe("Number of rows to preview (default: 10, max: 100)")
 			},
 			async ({ resource_id, limit }) => {
-				// Read API URL dynamically from env
 				console.error('[PREVIEW] API URL:', apiUrl);
 
 				const maxLimit = Math.min(limit, 100);
@@ -362,7 +360,6 @@ export default {
 		if (orgMatch) {
 			const [, hasAt, orgName, endpoint] = orgMatch;
 
-			// Set org-scoped API URL
 			CURRENT_API_URL = `https://api.cloud.portaljs.com/@${orgName}`;
 			console.error('[ROUTER] Org:', orgName, 'Set CURRENT_API_URL to:', CURRENT_API_URL);
 
@@ -374,7 +371,6 @@ export default {
 			}
 		}
 
-		// Reset to default API URL for legacy routes
 		CURRENT_API_URL = "https://api.cloud.portaljs.com";
 
 		if (pathname === "/sse" || pathname === "/sse/message") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -356,14 +356,15 @@ export default {
 
 		if (orgMatch) {
 			const [, hasAt, orgName, endpoint] = orgMatch;
+			const prefix = hasAt ? "@" : "";
 
-			CURRENT_API_URL = `https://api.cloud.portaljs.com/@${orgName}`;
+			CURRENT_API_URL = `https://api.cloud.portaljs.com/${prefix}${orgName}`;
 
 			if (endpoint === "sse") {
-				return MyMCP.serveSSE(`/${orgName}/sse`).fetch(request, env, ctx);
+				return MyMCP.serveSSE(`/${prefix}${orgName}/sse`).fetch(request, env, ctx);
 			}
 			if (endpoint === "mcp") {
-				return MyMCP.serve(`/${orgName}/mcp`).fetch(request, env, ctx);
+				return MyMCP.serve(`/${prefix}${orgName}/mcp`).fetch(request, env, ctx);
 			}
 		}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,444 +3,354 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
 interface Env {
+	API_URL?: string;
 }
 
-function createMCPServer(organization?: string) {
-	const apiUrl = "https://api.cloud.portaljs.com";
-
-	console.error('[MCP] Creating server with organization:', organization);
-
-	const server = new McpServer({
+// Define our MCP agent with tools
+export class MyMCP extends McpAgent<Env> {
+	server = new McpServer({
 		name: "PortalJS MCP Server",
 		version: "1.0.0",
 	});
 
-	// Search tool
-	server.tool(
-		"search",
-		"Search for datasets in PortalJS. Display the search results to the user in a readable format.",
-		{
-			query: z.string().describe("Search query to find datasets"),
-			limit: z.number().optional().default(10).describe("Maximum number of results to return (default: 10)")
-		},
-		async ({ query, limit }) => {
-			let endpoint = `${apiUrl}/api/3/action/package_search?q=${encodeURIComponent(query)}&rows=${limit}`;
+	async init() {
+		const apiUrl = this.props?.env?.API_URL || "https://api.cloud.portaljs.com";
 
-			if (organization) {
-				endpoint += `&fq=organization:${encodeURIComponent(organization)}`;
-				console.error('[SEARCH] Filtering by organization:', organization);
-			}
+		// Search tool
+		this.server.tool(
+			"search",
+			"Search for datasets in PortalJS. Display the search results to the user in a readable format.",
+			{
+				query: z.string().describe("Search query to find datasets"),
+				limit: z.number().optional().default(10).describe("Maximum number of results to return (default: 10)")
+			},
+			async ({ query, limit }) => {
+				const endpoint = `${apiUrl}/api/3/action/package_search?q=${encodeURIComponent(query)}&rows=${limit}`;
 
-			const response = await fetch(endpoint, {
-				method: "GET",
-				headers: {
-					"Content-Type": "application/json",
-					"User-Agent": "MCP-PortalJS-Server/1.0"
-				}
-			});
-
-			if (!response.ok) {
-				return {
-					content: [{
-						type: "text",
-						text: `Error: API returned ${response.status} ${response.statusText}`
-					}]
-				};
-			}
-
-			const data = await response.json();
-
-			if (!data.success) {
-				return {
-					content: [{
-						type: "text",
-						text: `Error: ${JSON.stringify(data.error)}`
-					}]
-				};
-			}
-
-			const results = data.result && data.result.results ? data.result.results.map((item: any) => ({
-				id: item.id,
-				name: item.name,
-				title: item.title,
-				description: item.notes,
-				url: `${apiUrl}/dataset/${item.name}`,
-				organization: item.organization?.name,
-				tags: item.tags?.map((tag: any) => tag.name),
-				created: item.metadata_created,
-				modified: item.metadata_modified,
-			})) : [];
-
-			return {
-				content: [{
-					type: "text",
-					text: JSON.stringify({
-						query,
-						organization: organization || "all",
-						total_results: results.length,
-						results
-					}, null, 2)
-				}]
-			};
-		}
-	);
-
-	// Fetch tool
-	server.tool(
-		"fetch",
-		"Fetch and display detailed information about a specific dataset including its resources, metadata, and properties.",
-		{
-			id: z.string().describe("ID or name of the dataset to fetch")
-		},
-		async ({ id }) => {
-			const endpoint = `${apiUrl}/api/3/action/package_show?id=${encodeURIComponent(id)}`;
-
-			const response = await fetch(endpoint, {
-				method: "GET",
-				headers: {
-					"Content-Type": "application/json",
-					"User-Agent": "MCP-PortalJS-Server/1.0"
-				}
-			});
-
-			if (!response.ok) {
-				return {
-					content: [{
-						type: "text",
-						text: `Error: API returned ${response.status} ${response.statusText}`
-					}]
-				};
-			}
-
-			const data = await response.json();
-
-			if (!data.success) {
-				return {
-					content: [{
-						type: "text",
-						text: `Error: ${JSON.stringify(data.error)}`
-					}]
-				};
-			}
-
-			if (!data.result) {
-				return {
-					content: [{
-						type: "text",
-						text: `Error: Missing result for request: ${id}`
-					}]
-				};
-			}
-
-			const result = data.result;
-
-			if (!result.id) {
-				return {
-					content: [{
-						type: "text",
-						text: `Error: Dataset not found: ${id}`
-					}]
-				};
-			}
-
-			if (organization && result.organization?.name !== organization) {
-				return {
-					content: [{
-						type: "text",
-						text: `Error: Dataset '${id}' not found in organization '${organization}'`
-					}]
-				};
-			}
-
-			const dataset = {
-				id: result.id,
-				name: result.name,
-				title: result.title || null,
-				description: result.notes || null,
-				url: `${apiUrl}/dataset/${result.name}`,
-				organization: result.organization || null,
-				tags: Array.isArray(result.tags) ? result.tags : [],
-				resources: Array.isArray(result.resources) ? result.resources : [],
-				groups: Array.isArray(result.groups) ? result.groups : [],
-				created: result.metadata_created,
-				modified: result.metadata_modified,
-				license: result.license_title || null,
-				maintainer: result.maintainer || null,
-				author: result.author || null,
-				state: result.state,
-			};
-
-			return {
-				content: [{
-					type: "text",
-					text: JSON.stringify(dataset, null, 2)
-				}]
-			};
-		}
-	);
-
-	// Preview data as table
-	server.tool(
-		"preview_data_table",
-		"Preview and display dataset resource data in a table format. Use this when user wants to see, preview, or display data from a resource. IMPORTANT: Always display the returned markdown table directly in the chat response to the user.",
-		{
-			resource_id: z.string().describe("ID of the resource to preview"),
-			limit: z.number().optional().default(10).describe("Number of rows to preview (default: 10, max: 100)")
-		},
-		async ({ resource_id, limit }) => {
-			const maxLimit = Math.min(limit, 100);
-
-			const parseCSV = (text: string, rowLimit: number): { fields: string[], records: any[] } => {
-				const lines = text.split('\n').filter(line => line.trim());
-				if (lines.length === 0) return { fields: [], records: [] };
-
-				const parseLine = (line: string): string[] => {
-					const result: string[] = [];
-					let current = '';
-					let inQuotes = false;
-
-					for (let i = 0; i < line.length; i++) {
-						const char = line[i];
-						if (char === '"') {
-							if (inQuotes && line[i + 1] === '"') {
-								current += '"';
-								i++;
-							} else {
-								inQuotes = !inQuotes;
-							}
-						} else if (char === ',' && !inQuotes) {
-							result.push(current.trim());
-							current = '';
-						} else {
-							current += char;
-						}
+				const response = await fetch(endpoint, {
+					method: "GET",
+					headers: {
+						"Content-Type": "application/json",
+						"User-Agent": "MCP-PortalJS-Server/1.0"
 					}
-					result.push(current.trim());
-					return result;
-				};
-
-				const fields = parseLine(lines[0]);
-				const records = lines.slice(1, rowLimit + 1).map(line => {
-					const values = parseLine(line);
-					const record: any = {};
-					fields.forEach((field, i) => {
-						record[field] = values[i] || '';
-					});
-					return record;
 				});
 
-				return { fields, records };
-			};
-
-			const buildTable = (fields: string[], records: any[], metadata: { source: string, url?: string, total?: number, showing: number }) => {
-				if (records.length === 0) return 'No data found in this resource.';
-
-				const header = `| ${fields.join(' | ')} |`;
-				const separator = `| ${fields.map(() => '---').join(' | ')} |`;
-				const rows = records.map((record: any) => {
-					const values = fields.map((field: string) => {
-						const value = record[field];
-						if (value === null || value === undefined) return '';
-						return String(value).replace(/\|/g, '\\|');
-					});
-					return `| ${values.join(' | ')} |`;
-				});
-
-				const metaLines = [
-					`**Source:** ${metadata.source}`,
-					metadata.url ? `**Download URL:** [Download Resource](${metadata.url})` : null,
-					metadata.total ? `**Total Records:** ${metadata.total}` : null,
-					`**Showing:** ${metadata.showing} rows\n`
-				].filter(Boolean);
-
-				return [...metaLines, header, separator, ...rows].join('\n');
-			};
-
-			try {
-				const resourceEndpoint = `${apiUrl}/api/3/action/resource_show?id=${encodeURIComponent(resource_id)}`;
-				const resourceResponse = await fetch(resourceEndpoint);
-				const resourceData = await resourceResponse.json();
-
-				if (!resourceData.success || !resourceData.result?.url) {
+				if (!response.ok) {
 					return {
 						content: [{
 							type: "text",
-							text: `Error: Resource not found or has no accessible URL.`
+							text: `Error: API returned ${response.status} ${response.statusText}`
 						}]
 					};
 				}
 
-				if (organization) {
-					const packageEndpoint = `${apiUrl}/api/3/action/package_show?id=${encodeURIComponent(resourceData.result.package_id)}`;
-					const packageResponse = await fetch(packageEndpoint);
-					const packageData = await packageResponse.json();
+				const data = await response.json();
 
-					if (packageData.success && packageData.result?.organization?.name !== organization) {
+				if (!data.success) {
+					return {
+						content: [{
+							type: "text",
+							text: `Error: ${JSON.stringify(data.error)}`
+						}]
+					};
+				}
+
+				const results = data.result && data.result.results ? data.result.results.map((item: any) => ({
+					id: item.id,
+					name: item.name,
+					title: item.title,
+					description: item.notes,
+					url: `${apiUrl}/dataset/${item.name}`,
+					organization: item.organization?.name,
+					tags: item.tags?.map((tag: any) => tag.name),
+					created: item.metadata_created,
+					modified: item.metadata_modified,
+				})) : [];
+
+				return {
+					content: [{
+						type: "text",
+						text: JSON.stringify({
+							query,
+							total_results: results.length,
+							results
+						}, null, 2)
+					}]
+				};
+			}
+		);
+
+		// Fetch tool
+		this.server.tool(
+			"fetch",
+			"Fetch and display detailed information about a specific dataset including its resources, metadata, and properties.",
+			{
+				id: z.string().describe("ID or name of the dataset to fetch")
+			},
+			async ({ id }) => {
+				const endpoint = `${apiUrl}/api/3/action/package_show?id=${encodeURIComponent(id)}`;
+
+				const response = await fetch(endpoint, {
+					method: "GET",
+					headers: {
+						"Content-Type": "application/json",
+						"User-Agent": "MCP-PortalJS-Server/1.0"
+					}
+				});
+
+				if (!response.ok) {
+					return {
+						content: [{
+							type: "text",
+							text: `Error: API returned ${response.status} ${response.statusText}`
+						}]
+					};
+				}
+
+				const data = await response.json();
+
+				if (!data.success) {
+					return {
+						content: [{
+							type: "text",
+							text: `Error: ${JSON.stringify(data.error)}`
+						}]
+					};
+				}
+
+				if (!data.result) {
+					return {
+						content: [{
+							type: "text",
+							text: `Error: Missing result for request: ${id}`
+						}]
+					};
+				}
+
+				const result = data.result;
+
+				if (!result.id) {
+					return {
+						content: [{
+							type: "text",
+							text: `Error: Dataset not found: ${id}`
+						}]
+					};
+				}
+
+				const dataset = {
+					id: result.id,
+					name: result.name,
+					title: result.title || null,
+					description: result.notes || null,
+					url: `${apiUrl}/dataset/${result.name}`,
+					organization: result.organization || null,
+					tags: Array.isArray(result.tags) ? result.tags : [],
+					resources: Array.isArray(result.resources) ? result.resources : [],
+					groups: Array.isArray(result.groups) ? result.groups : [],
+					created: result.metadata_created,
+					modified: result.metadata_modified,
+					license: result.license_title || null,
+					maintainer: result.maintainer || null,
+					author: result.author || null,
+					state: result.state,
+				};
+
+				return {
+					content: [{
+						type: "text",
+						text: JSON.stringify(dataset, null, 2)
+					}]
+				};
+			}
+		);
+
+		// Preview data as table
+		this.server.tool(
+			"preview_data_table",
+			"Preview and display dataset resource data in a table format. Use this when user wants to see, preview, or display data from a resource. IMPORTANT: Always display the returned markdown table directly in the chat response to the user.",
+			{
+				resource_id: z.string().describe("ID of the resource to preview"),
+				limit: z.number().optional().default(10).describe("Number of rows to preview (default: 10, max: 100)")
+			},
+			async ({ resource_id, limit }) => {
+				const maxLimit = Math.min(limit, 100);
+
+				const parseCSV = (text: string, rowLimit: number): { fields: string[], records: any[] } => {
+					const lines = text.split('\n').filter(line => line.trim());
+					if (lines.length === 0) return { fields: [], records: [] };
+
+					const parseLine = (line: string): string[] => {
+						const result: string[] = [];
+						let current = '';
+						let inQuotes = false;
+
+						for (let i = 0; i < line.length; i++) {
+							const char = line[i];
+							if (char === '"') {
+								if (inQuotes && line[i + 1] === '"') {
+									current += '"';
+									i++;
+								} else {
+									inQuotes = !inQuotes;
+								}
+							} else if (char === ',' && !inQuotes) {
+								result.push(current.trim());
+								current = '';
+							} else {
+								current += char;
+							}
+						}
+						result.push(current.trim());
+						return result;
+					};
+
+					const fields = parseLine(lines[0]);
+					const records = lines.slice(1, rowLimit + 1).map(line => {
+						const values = parseLine(line);
+						const record: any = {};
+						fields.forEach((field, i) => {
+							record[field] = values[i] || '';
+						});
+						return record;
+					});
+
+					return { fields, records };
+				};
+
+				const buildTable = (fields: string[], records: any[], metadata: { source: string, url?: string, total?: number, showing: number }) => {
+					if (records.length === 0) return 'No data found in this resource.';
+
+					const header = `| ${fields.join(' | ')} |`;
+					const separator = `| ${fields.map(() => '---').join(' | ')} |`;
+					const rows = records.map((record: any) => {
+						const values = fields.map((field: string) => {
+							const value = record[field];
+							if (value === null || value === undefined) return '';
+							return String(value).replace(/\|/g, '\\|');
+						});
+						return `| ${values.join(' | ')} |`;
+					});
+
+					const metaLines = [
+						`**Source:** ${metadata.source}`,
+						metadata.url ? `**Download URL:** [Download Resource](${metadata.url})` : null,
+						metadata.total ? `**Total Records:** ${metadata.total}` : null,
+						`**Showing:** ${metadata.showing} rows\n`
+					].filter(Boolean);
+
+					return [...metaLines, header, separator, ...rows].join('\n');
+				};
+
+				try {
+					const resourceEndpoint = `${apiUrl}/api/3/action/resource_show?id=${encodeURIComponent(resource_id)}`;
+					const resourceResponse = await fetch(resourceEndpoint);
+					const resourceData = await resourceResponse.json();
+
+					if (!resourceData.success || !resourceData.result?.url) {
 						return {
 							content: [{
 								type: "text",
-								text: `Error: Resource not found in organization '${organization}'`
+								text: `Error: Resource not found or has no accessible URL.`
 							}]
 						};
 					}
-				}
 
-				const resourceUrl = resourceData.result.url;
-				const format = (resourceData.result.format || '').toLowerCase();
+					const resourceUrl = resourceData.result.url;
+					const format = (resourceData.result.format || '').toLowerCase();
 
-				try {
-					const datastoreEndpoint = `${apiUrl}/api/3/action/datastore_search?resource_id=${encodeURIComponent(resource_id)}&limit=${maxLimit}`;
-					const datastoreResponse = await fetch(datastoreEndpoint);
-					const datastoreData = await datastoreResponse.json();
+					try {
+						const datastoreEndpoint = `${apiUrl}/api/3/action/datastore_search?resource_id=${encodeURIComponent(resource_id)}&limit=${maxLimit}`;
+						const datastoreResponse = await fetch(datastoreEndpoint);
+						const datastoreData = await datastoreResponse.json();
 
-					if (datastoreData.success && datastoreData.result?.records) {
-						const records = datastoreData.result.records;
-						const fields = datastoreData.result.fields?.map((f: any) => f.id).filter((id: string) => id !== '_id') || [];
+						if (datastoreData.success && datastoreData.result?.records) {
+							const records = datastoreData.result.records;
+							const fields = datastoreData.result.fields?.map((f: any) => f.id).filter((id: string) => id !== '_id') || [];
+
+							const table = buildTable(fields, records, {
+								source: 'DataStore',
+								url: resourceUrl,
+								total: datastoreData.result.total,
+								showing: records.length
+							});
+
+							return { content: [{ type: "text", text: table }] };
+						}
+					} catch (datastoreError) {
+						// DataStore failed, continue to fallback
+					}
+
+					const dataResponse = await fetch(resourceUrl);
+					if (!dataResponse.ok) {
+						return {
+							content: [{
+								type: "text",
+								text: `Error: Failed to fetch resource data (HTTP ${dataResponse.status}).`
+							}]
+						};
+					}
+
+					const contentType = dataResponse.headers.get('content-type') || '';
+					const rawData = await dataResponse.text();
+
+					if (format === 'json' || contentType.includes('json')) {
+						const parsed = JSON.parse(rawData);
+						const array = Array.isArray(parsed) ? parsed : [parsed];
+						const records = array.slice(0, maxLimit);
+						const fields = records.length > 0 ? Object.keys(records[0]) : [];
 
 						const table = buildTable(fields, records, {
-							source: 'DataStore',
+							source: 'Direct fetch (JSON)',
 							url: resourceUrl,
-							total: datastoreData.result.total,
 							showing: records.length
 						});
 
 						return { content: [{ type: "text", text: table }] };
 					}
-				} catch (datastoreError) {
-					// DataStore failed, continue to fallback
-				}
 
-				const dataResponse = await fetch(resourceUrl);
-				if (!dataResponse.ok) {
+					if (format === 'csv' || contentType.includes('csv') || resourceUrl.endsWith('.csv')) {
+						const { fields, records } = parseCSV(rawData, maxLimit);
+
+						const table = buildTable(fields, records, {
+							source: 'Direct fetch (CSV)',
+							url: resourceUrl,
+							showing: records.length
+						});
+
+						return { content: [{ type: "text", text: table }] };
+					}
+
 					return {
 						content: [{
 							type: "text",
-							text: `Error: Failed to fetch resource data (HTTP ${dataResponse.status}).`
+							text: `Error: Unsupported format '${format}'. Only CSV and JSON are supported.`
+						}]
+					};
+
+				} catch (error) {
+					return {
+						content: [{
+							type: "text",
+							text: `Error: Failed to preview data. ${error instanceof Error ? error.message : 'Unknown error'}`
 						}]
 					};
 				}
-
-				const contentType = dataResponse.headers.get('content-type') || '';
-				const rawData = await dataResponse.text();
-
-				if (format === 'json' || contentType.includes('json')) {
-					const parsed = JSON.parse(rawData);
-					const array = Array.isArray(parsed) ? parsed : [parsed];
-					const records = array.slice(0, maxLimit);
-					const fields = records.length > 0 ? Object.keys(records[0]) : [];
-
-					const table = buildTable(fields, records, {
-						source: 'Direct fetch (JSON)',
-						url: resourceUrl,
-						showing: records.length
-					});
-
-					return { content: [{ type: "text", text: table }] };
-				}
-
-				if (format === 'csv' || contentType.includes('csv') || resourceUrl.endsWith('.csv')) {
-					const { fields, records } = parseCSV(rawData, maxLimit);
-
-					const table = buildTable(fields, records, {
-						source: 'Direct fetch (CSV)',
-						url: resourceUrl,
-						showing: records.length
-					});
-
-					return { content: [{ type: "text", text: table }] };
-				}
-
-				return {
-					content: [{
-						type: "text",
-						text: `Error: Unsupported format '${format}'. Only CSV and JSON are supported.`
-					}]
-				};
-
-			} catch (error) {
-				return {
-					content: [{
-						type: "text",
-						text: `Error: Failed to preview data. ${error instanceof Error ? error.message : 'Unknown error'}`
-					}]
-				};
 			}
-		}
-	);
-
-	return server;
-}
-
-const agentCache = new Map<string, typeof McpAgent<Env>>();
-
-function getAgentClass(organization?: string): typeof McpAgent<Env> {
-	const cacheKey = organization || "_default";
-
-	if (!agentCache.has(cacheKey)) {
-		const server = createMCPServer(organization);
-		const AgentClass = class extends McpAgent<Env> {
-			server = server;
-			async init() {
-			}
-		};
-		agentCache.set(cacheKey, AgentClass);
-	}
-
-	return agentCache.get(cacheKey)!;
-}
-
-export class MyMCP extends McpAgent<Env> {
-	server = createMCPServer();
-	async init() {
+		);
 	}
 }
 
 export default {
 	fetch(request: Request, env: Env, ctx: ExecutionContext) {
 		const url = new URL(request.url);
-		const pathname = url.pathname;
 
-		// Parse organization from URL path
-		// Supports: /@org-name/sse, /@org-name/sse/message, /@org-name/mcp
-		// Also supports: /org-name/sse (without @)
-		const orgMatch = pathname.match(/^\/(@)?([^\/]+)\/(sse|mcp)(\/.*)?$/);
-
-		if (orgMatch) {
-			const [, hasAt, orgName, endpoint, subpath] = orgMatch;
-
-			console.error('[FETCH] Matched org path:', pathname);
-			console.error('[FETCH] Extracted org name:', orgName);
-
-			const AgentClass = getAgentClass(orgName);
-
-			const rewrittenUrl = new URL(request.url);
-			rewrittenUrl.pathname = `/${endpoint}${subpath || ''}`;
-
-			const rewrittenRequest = new Request(rewrittenUrl.toString(), {
-				method: request.method,
-				headers: request.headers,
-				body: request.body,
-				duplex: 'half'
-			});
-
-			if (endpoint === "sse") {
-				return AgentClass.serveSSE("/sse").fetch(rewrittenRequest, env, ctx);
-			}
-
-			if (endpoint === "mcp") {
-				return AgentClass.serve("/mcp").fetch(rewrittenRequest, env, ctx);
-			}
+		if (url.pathname === "/sse" || url.pathname === "/sse/message") {
+			return MyMCP.serveSSE("/sse").fetch(request, env, ctx);
 		}
 
-		// Legacy routes (no organization)
-		if (pathname === "/sse" || pathname === "/sse/message") {
-			const AgentClass = getAgentClass();
-			return AgentClass.serveSSE("/sse").fetch(request, env, ctx);
-		}
-
-		if (pathname === "/mcp") {
-			const AgentClass = getAgentClass();
-			return AgentClass.serve("/mcp").fetch(request, env, ctx);
+		if (url.pathname === "/mcp") {
+			return MyMCP.serve("/mcp").fetch(request, env, ctx);
 		}
 
 		return new Response("Not found", { status: 404 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 
 interface Env {
 	API_URL?: string;
+	ORGANIZATION?: string;
 }
 
 // Define our MCP agent with tools
@@ -15,6 +16,7 @@ export class MyMCP extends McpAgent<Env> {
 
 	async init() {
 		const apiUrl = this.props?.env?.API_URL || "https://api.cloud.portaljs.com";
+		const organization = this.props?.env?.ORGANIZATION;
 
 		// Search tool
 		this.server.tool(
@@ -25,7 +27,11 @@ export class MyMCP extends McpAgent<Env> {
 				limit: z.number().optional().default(10).describe("Maximum number of results to return (default: 10)")
 			},
 			async ({ query, limit }) => {
-				const endpoint = `${apiUrl}/api/3/action/package_search?q=${encodeURIComponent(query)}&rows=${limit}`;
+				let endpoint = `${apiUrl}/api/3/action/package_search?q=${encodeURIComponent(query)}&rows=${limit}`;
+
+				if (organization) {
+					endpoint += `&fq=organization:${encodeURIComponent(organization)}`;
+				}
 
 				const response = await fetch(endpoint, {
 					method: "GET",
@@ -72,6 +78,7 @@ export class MyMCP extends McpAgent<Env> {
 						type: "text",
 						text: JSON.stringify({
 							query,
+							organization: organization || "all",
 							total_results: results.length,
 							results
 						}, null, 2)
@@ -134,6 +141,15 @@ export class MyMCP extends McpAgent<Env> {
 						content: [{
 							type: "text",
 							text: `Error: Dataset not found: ${id}`
+						}]
+					};
+				}
+
+				if (organization && result.organization?.name !== organization) {
+					return {
+						content: [{
+							type: "text",
+							text: `Error: Dataset '${id}' not found in organization '${organization}'`
 						}]
 					};
 				}
@@ -256,6 +272,21 @@ export class MyMCP extends McpAgent<Env> {
 						};
 					}
 
+					if (organization) {
+						const packageEndpoint = `${apiUrl}/api/3/action/package_show?id=${encodeURIComponent(resourceData.result.package_id)}`;
+						const packageResponse = await fetch(packageEndpoint);
+						const packageData = await packageResponse.json();
+
+						if (packageData.success && packageData.result?.organization?.name !== organization) {
+							return {
+								content: [{
+									type: "text",
+									text: `Error: Resource not found in organization '${organization}'`
+								}]
+							};
+						}
+					}
+
 					const resourceUrl = resourceData.result.url;
 					const format = (resourceData.result.format || '').toLowerCase();
 
@@ -345,12 +376,44 @@ export default {
 	fetch(request: Request, env: Env, ctx: ExecutionContext) {
 		const url = new URL(request.url);
 
-		if (url.pathname === "/sse" || url.pathname === "/sse/message") {
-			return MyMCP.serveSSE("/sse").fetch(request, env, ctx);
+		const pathParts = url.pathname.split('/').filter(p => p);
+		let organization: string | undefined;
+		let matchedPath: string | undefined;
+
+		if (pathParts.length >= 2 && pathParts[0].startsWith('@') && pathParts[1] === 'sse') {
+			organization = pathParts[0].substring(1); // Remove @ prefix
+			matchedPath = '/sse';
+		}
+		else if (pathParts.length >= 3 && pathParts[0].startsWith('@') && pathParts[1] === 'sse' && pathParts[2] === 'message') {
+			organization = pathParts[0].substring(1); // Remove @ prefix
+			matchedPath = '/sse/message';
+		}
+		else if (pathParts.length >= 2 && pathParts[0].startsWith('@') && pathParts[1] === 'mcp') {
+			organization = pathParts[0].substring(1); // Remove @ prefix
+			matchedPath = '/mcp';
+		}
+		else if (url.pathname === "/sse" || url.pathname === "/sse/message") {
+			matchedPath = url.pathname;
+		}
+		else if (url.pathname === "/mcp") {
+			matchedPath = "/mcp";
 		}
 
-		if (url.pathname === "/mcp") {
-			return MyMCP.serve("/mcp").fetch(request, env, ctx);
+		if (!matchedPath) {
+			return new Response("Not found", { status: 404 });
+		}
+
+		const envWithOrg: Env = {
+			...env,
+			ORGANIZATION: organization
+		};
+
+		if (matchedPath === "/sse" || matchedPath === "/sse/message") {
+			return MyMCP.serveSSE("/sse").fetch(request, envWithOrg, ctx);
+		}
+
+		if (matchedPath === "/mcp") {
+			return MyMCP.serve("/mcp").fetch(request, envWithOrg, ctx);
 		}
 
 		return new Response("Not found", { status: 404 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,8 +95,6 @@ export class MyMCP extends McpAgent {
 				const apiUrl = CURRENT_API_URL;
 				const endpoint = `${apiUrl}/api/3/action/package_show?id=${encodeURIComponent(id)}`;
 
-				console.error('[FETCH] API URL:', apiUrl);
-
 				const response = await fetch(endpoint, {
 					method: "GET",
 					headers: {
@@ -181,8 +179,7 @@ export class MyMCP extends McpAgent {
 				limit: z.number().optional().default(10).describe("Number of rows to preview (default: 10, max: 100)")
 			},
 			async ({ resource_id, limit }) => {
-				console.error('[PREVIEW] API URL:', apiUrl);
-
+				const apiUrl = CURRENT_API_URL;
 				const maxLimit = Math.min(limit, 100);
 
 				const parseCSV = (text: string, rowLimit: number): { fields: string[], records: any[] } => {
@@ -361,7 +358,6 @@ export default {
 			const [, hasAt, orgName, endpoint] = orgMatch;
 
 			CURRENT_API_URL = `https://api.cloud.portaljs.com/@${orgName}`;
-			console.error('[ROUTER] Org:', orgName, 'Set CURRENT_API_URL to:', CURRENT_API_URL);
 
 			if (endpoint === "sse") {
 				return MyMCP.serveSSE(`/${orgName}/sse`).fetch(request, env, ctx);

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,354 +3,444 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
 interface Env {
-	API_URL?: string;
 }
 
-// Define our MCP agent with tools
-export class MyMCP extends McpAgent<Env> {
-	server = new McpServer({
+function createMCPServer(organization?: string) {
+	const apiUrl = "https://api.cloud.portaljs.com";
+
+	console.error('[MCP] Creating server with organization:', organization);
+
+	const server = new McpServer({
 		name: "PortalJS MCP Server",
 		version: "1.0.0",
 	});
 
-	async init() {
-		const apiUrl = this.props?.env?.API_URL || "https://api.cloud.portaljs.com";
+	// Search tool
+	server.tool(
+		"search",
+		"Search for datasets in PortalJS. Display the search results to the user in a readable format.",
+		{
+			query: z.string().describe("Search query to find datasets"),
+			limit: z.number().optional().default(10).describe("Maximum number of results to return (default: 10)")
+		},
+		async ({ query, limit }) => {
+			let endpoint = `${apiUrl}/api/3/action/package_search?q=${encodeURIComponent(query)}&rows=${limit}`;
 
-		// Search tool
-		this.server.tool(
-			"search",
-			"Search for datasets in PortalJS. Display the search results to the user in a readable format.",
-			{
-				query: z.string().describe("Search query to find datasets"),
-				limit: z.number().optional().default(10).describe("Maximum number of results to return (default: 10)")
-			},
-			async ({ query, limit }) => {
-				const endpoint = `${apiUrl}/api/3/action/package_search?q=${encodeURIComponent(query)}&rows=${limit}`;
+			if (organization) {
+				endpoint += `&fq=organization:${encodeURIComponent(organization)}`;
+				console.error('[SEARCH] Filtering by organization:', organization);
+			}
 
-				const response = await fetch(endpoint, {
-					method: "GET",
-					headers: {
-						"Content-Type": "application/json",
-						"User-Agent": "MCP-PortalJS-Server/1.0"
-					}
-				});
-
-				if (!response.ok) {
-					return {
-						content: [{
-							type: "text",
-							text: `Error: API returned ${response.status} ${response.statusText}`
-						}]
-					};
+			const response = await fetch(endpoint, {
+				method: "GET",
+				headers: {
+					"Content-Type": "application/json",
+					"User-Agent": "MCP-PortalJS-Server/1.0"
 				}
+			});
 
-				const data = await response.json();
-
-				if (!data.success) {
-					return {
-						content: [{
-							type: "text",
-							text: `Error: ${JSON.stringify(data.error)}`
-						}]
-					};
-				}
-
-				const results = data.result && data.result.results ? data.result.results.map((item: any) => ({
-					id: item.id,
-					name: item.name,
-					title: item.title,
-					description: item.notes,
-					url: `${apiUrl}/dataset/${item.name}`,
-					organization: item.organization?.name,
-					tags: item.tags?.map((tag: any) => tag.name),
-					created: item.metadata_created,
-					modified: item.metadata_modified,
-				})) : [];
-
+			if (!response.ok) {
 				return {
 					content: [{
 						type: "text",
-						text: JSON.stringify({
-							query,
-							total_results: results.length,
-							results
-						}, null, 2)
+						text: `Error: API returned ${response.status} ${response.statusText}`
 					}]
 				};
 			}
-		);
 
-		// Fetch tool
-		this.server.tool(
-			"fetch",
-			"Fetch and display detailed information about a specific dataset including its resources, metadata, and properties.",
-			{
-				id: z.string().describe("ID or name of the dataset to fetch")
-			},
-			async ({ id }) => {
-				const endpoint = `${apiUrl}/api/3/action/package_show?id=${encodeURIComponent(id)}`;
+			const data = await response.json();
 
-				const response = await fetch(endpoint, {
-					method: "GET",
-					headers: {
-						"Content-Type": "application/json",
-						"User-Agent": "MCP-PortalJS-Server/1.0"
-					}
-				});
-
-				if (!response.ok) {
-					return {
-						content: [{
-							type: "text",
-							text: `Error: API returned ${response.status} ${response.statusText}`
-						}]
-					};
-				}
-
-				const data = await response.json();
-
-				if (!data.success) {
-					return {
-						content: [{
-							type: "text",
-							text: `Error: ${JSON.stringify(data.error)}`
-						}]
-					};
-				}
-
-				if (!data.result) {
-					return {
-						content: [{
-							type: "text",
-							text: `Error: Missing result for request: ${id}`
-						}]
-					};
-				}
-
-				const result = data.result;
-
-				if (!result.id) {
-					return {
-						content: [{
-							type: "text",
-							text: `Error: Dataset not found: ${id}`
-						}]
-					};
-				}
-
-				const dataset = {
-					id: result.id,
-					name: result.name,
-					title: result.title || null,
-					description: result.notes || null,
-					url: `${apiUrl}/dataset/${result.name}`,
-					organization: result.organization || null,
-					tags: Array.isArray(result.tags) ? result.tags : [],
-					resources: Array.isArray(result.resources) ? result.resources : [],
-					groups: Array.isArray(result.groups) ? result.groups : [],
-					created: result.metadata_created,
-					modified: result.metadata_modified,
-					license: result.license_title || null,
-					maintainer: result.maintainer || null,
-					author: result.author || null,
-					state: result.state,
-				};
-
+			if (!data.success) {
 				return {
 					content: [{
 						type: "text",
-						text: JSON.stringify(dataset, null, 2)
+						text: `Error: ${JSON.stringify(data.error)}`
 					}]
 				};
 			}
-		);
 
-		// Preview data as table
-		this.server.tool(
-			"preview_data_table",
-			"Preview and display dataset resource data in a table format. Use this when user wants to see, preview, or display data from a resource. IMPORTANT: Always display the returned markdown table directly in the chat response to the user.",
-			{
-				resource_id: z.string().describe("ID of the resource to preview"),
-				limit: z.number().optional().default(10).describe("Number of rows to preview (default: 10, max: 100)")
-			},
-			async ({ resource_id, limit }) => {
-				const maxLimit = Math.min(limit, 100);
+			const results = data.result && data.result.results ? data.result.results.map((item: any) => ({
+				id: item.id,
+				name: item.name,
+				title: item.title,
+				description: item.notes,
+				url: `${apiUrl}/dataset/${item.name}`,
+				organization: item.organization?.name,
+				tags: item.tags?.map((tag: any) => tag.name),
+				created: item.metadata_created,
+				modified: item.metadata_modified,
+			})) : [];
 
-				const parseCSV = (text: string, rowLimit: number): { fields: string[], records: any[] } => {
-					const lines = text.split('\n').filter(line => line.trim());
-					if (lines.length === 0) return { fields: [], records: [] };
+			return {
+				content: [{
+					type: "text",
+					text: JSON.stringify({
+						query,
+						organization: organization || "all",
+						total_results: results.length,
+						results
+					}, null, 2)
+				}]
+			};
+		}
+	);
 
-					const parseLine = (line: string): string[] => {
-						const result: string[] = [];
-						let current = '';
-						let inQuotes = false;
+	// Fetch tool
+	server.tool(
+		"fetch",
+		"Fetch and display detailed information about a specific dataset including its resources, metadata, and properties.",
+		{
+			id: z.string().describe("ID or name of the dataset to fetch")
+		},
+		async ({ id }) => {
+			const endpoint = `${apiUrl}/api/3/action/package_show?id=${encodeURIComponent(id)}`;
 
-						for (let i = 0; i < line.length; i++) {
-							const char = line[i];
-							if (char === '"') {
-								if (inQuotes && line[i + 1] === '"') {
-									current += '"';
-									i++;
-								} else {
-									inQuotes = !inQuotes;
-								}
-							} else if (char === ',' && !inQuotes) {
-								result.push(current.trim());
-								current = '';
+			const response = await fetch(endpoint, {
+				method: "GET",
+				headers: {
+					"Content-Type": "application/json",
+					"User-Agent": "MCP-PortalJS-Server/1.0"
+				}
+			});
+
+			if (!response.ok) {
+				return {
+					content: [{
+						type: "text",
+						text: `Error: API returned ${response.status} ${response.statusText}`
+					}]
+				};
+			}
+
+			const data = await response.json();
+
+			if (!data.success) {
+				return {
+					content: [{
+						type: "text",
+						text: `Error: ${JSON.stringify(data.error)}`
+					}]
+				};
+			}
+
+			if (!data.result) {
+				return {
+					content: [{
+						type: "text",
+						text: `Error: Missing result for request: ${id}`
+					}]
+				};
+			}
+
+			const result = data.result;
+
+			if (!result.id) {
+				return {
+					content: [{
+						type: "text",
+						text: `Error: Dataset not found: ${id}`
+					}]
+				};
+			}
+
+			if (organization && result.organization?.name !== organization) {
+				return {
+					content: [{
+						type: "text",
+						text: `Error: Dataset '${id}' not found in organization '${organization}'`
+					}]
+				};
+			}
+
+			const dataset = {
+				id: result.id,
+				name: result.name,
+				title: result.title || null,
+				description: result.notes || null,
+				url: `${apiUrl}/dataset/${result.name}`,
+				organization: result.organization || null,
+				tags: Array.isArray(result.tags) ? result.tags : [],
+				resources: Array.isArray(result.resources) ? result.resources : [],
+				groups: Array.isArray(result.groups) ? result.groups : [],
+				created: result.metadata_created,
+				modified: result.metadata_modified,
+				license: result.license_title || null,
+				maintainer: result.maintainer || null,
+				author: result.author || null,
+				state: result.state,
+			};
+
+			return {
+				content: [{
+					type: "text",
+					text: JSON.stringify(dataset, null, 2)
+				}]
+			};
+		}
+	);
+
+	// Preview data as table
+	server.tool(
+		"preview_data_table",
+		"Preview and display dataset resource data in a table format. Use this when user wants to see, preview, or display data from a resource. IMPORTANT: Always display the returned markdown table directly in the chat response to the user.",
+		{
+			resource_id: z.string().describe("ID of the resource to preview"),
+			limit: z.number().optional().default(10).describe("Number of rows to preview (default: 10, max: 100)")
+		},
+		async ({ resource_id, limit }) => {
+			const maxLimit = Math.min(limit, 100);
+
+			const parseCSV = (text: string, rowLimit: number): { fields: string[], records: any[] } => {
+				const lines = text.split('\n').filter(line => line.trim());
+				if (lines.length === 0) return { fields: [], records: [] };
+
+				const parseLine = (line: string): string[] => {
+					const result: string[] = [];
+					let current = '';
+					let inQuotes = false;
+
+					for (let i = 0; i < line.length; i++) {
+						const char = line[i];
+						if (char === '"') {
+							if (inQuotes && line[i + 1] === '"') {
+								current += '"';
+								i++;
 							} else {
-								current += char;
+								inQuotes = !inQuotes;
 							}
+						} else if (char === ',' && !inQuotes) {
+							result.push(current.trim());
+							current = '';
+						} else {
+							current += char;
 						}
-						result.push(current.trim());
-						return result;
+					}
+					result.push(current.trim());
+					return result;
+				};
+
+				const fields = parseLine(lines[0]);
+				const records = lines.slice(1, rowLimit + 1).map(line => {
+					const values = parseLine(line);
+					const record: any = {};
+					fields.forEach((field, i) => {
+						record[field] = values[i] || '';
+					});
+					return record;
+				});
+
+				return { fields, records };
+			};
+
+			const buildTable = (fields: string[], records: any[], metadata: { source: string, url?: string, total?: number, showing: number }) => {
+				if (records.length === 0) return 'No data found in this resource.';
+
+				const header = `| ${fields.join(' | ')} |`;
+				const separator = `| ${fields.map(() => '---').join(' | ')} |`;
+				const rows = records.map((record: any) => {
+					const values = fields.map((field: string) => {
+						const value = record[field];
+						if (value === null || value === undefined) return '';
+						return String(value).replace(/\|/g, '\\|');
+					});
+					return `| ${values.join(' | ')} |`;
+				});
+
+				const metaLines = [
+					`**Source:** ${metadata.source}`,
+					metadata.url ? `**Download URL:** [Download Resource](${metadata.url})` : null,
+					metadata.total ? `**Total Records:** ${metadata.total}` : null,
+					`**Showing:** ${metadata.showing} rows\n`
+				].filter(Boolean);
+
+				return [...metaLines, header, separator, ...rows].join('\n');
+			};
+
+			try {
+				const resourceEndpoint = `${apiUrl}/api/3/action/resource_show?id=${encodeURIComponent(resource_id)}`;
+				const resourceResponse = await fetch(resourceEndpoint);
+				const resourceData = await resourceResponse.json();
+
+				if (!resourceData.success || !resourceData.result?.url) {
+					return {
+						content: [{
+							type: "text",
+							text: `Error: Resource not found or has no accessible URL.`
+						}]
 					};
+				}
 
-					const fields = parseLine(lines[0]);
-					const records = lines.slice(1, rowLimit + 1).map(line => {
-						const values = parseLine(line);
-						const record: any = {};
-						fields.forEach((field, i) => {
-							record[field] = values[i] || '';
-						});
-						return record;
-					});
+				if (organization) {
+					const packageEndpoint = `${apiUrl}/api/3/action/package_show?id=${encodeURIComponent(resourceData.result.package_id)}`;
+					const packageResponse = await fetch(packageEndpoint);
+					const packageData = await packageResponse.json();
 
-					return { fields, records };
-				};
+					if (packageData.success && packageData.result?.organization?.name !== organization) {
+						return {
+							content: [{
+								type: "text",
+								text: `Error: Resource not found in organization '${organization}'`
+							}]
+						};
+					}
+				}
 
-				const buildTable = (fields: string[], records: any[], metadata: { source: string, url?: string, total?: number, showing: number }) => {
-					if (records.length === 0) return 'No data found in this resource.';
-
-					const header = `| ${fields.join(' | ')} |`;
-					const separator = `| ${fields.map(() => '---').join(' | ')} |`;
-					const rows = records.map((record: any) => {
-						const values = fields.map((field: string) => {
-							const value = record[field];
-							if (value === null || value === undefined) return '';
-							return String(value).replace(/\|/g, '\\|');
-						});
-						return `| ${values.join(' | ')} |`;
-					});
-
-					const metaLines = [
-						`**Source:** ${metadata.source}`,
-						metadata.url ? `**Download URL:** [Download Resource](${metadata.url})` : null,
-						metadata.total ? `**Total Records:** ${metadata.total}` : null,
-						`**Showing:** ${metadata.showing} rows\n`
-					].filter(Boolean);
-
-					return [...metaLines, header, separator, ...rows].join('\n');
-				};
+				const resourceUrl = resourceData.result.url;
+				const format = (resourceData.result.format || '').toLowerCase();
 
 				try {
-					const resourceEndpoint = `${apiUrl}/api/3/action/resource_show?id=${encodeURIComponent(resource_id)}`;
-					const resourceResponse = await fetch(resourceEndpoint);
-					const resourceData = await resourceResponse.json();
+					const datastoreEndpoint = `${apiUrl}/api/3/action/datastore_search?resource_id=${encodeURIComponent(resource_id)}&limit=${maxLimit}`;
+					const datastoreResponse = await fetch(datastoreEndpoint);
+					const datastoreData = await datastoreResponse.json();
 
-					if (!resourceData.success || !resourceData.result?.url) {
-						return {
-							content: [{
-								type: "text",
-								text: `Error: Resource not found or has no accessible URL.`
-							}]
-						};
-					}
-
-					const resourceUrl = resourceData.result.url;
-					const format = (resourceData.result.format || '').toLowerCase();
-
-					try {
-						const datastoreEndpoint = `${apiUrl}/api/3/action/datastore_search?resource_id=${encodeURIComponent(resource_id)}&limit=${maxLimit}`;
-						const datastoreResponse = await fetch(datastoreEndpoint);
-						const datastoreData = await datastoreResponse.json();
-
-						if (datastoreData.success && datastoreData.result?.records) {
-							const records = datastoreData.result.records;
-							const fields = datastoreData.result.fields?.map((f: any) => f.id).filter((id: string) => id !== '_id') || [];
-
-							const table = buildTable(fields, records, {
-								source: 'DataStore',
-								url: resourceUrl,
-								total: datastoreData.result.total,
-								showing: records.length
-							});
-
-							return { content: [{ type: "text", text: table }] };
-						}
-					} catch (datastoreError) {
-						// DataStore failed, continue to fallback
-					}
-
-					const dataResponse = await fetch(resourceUrl);
-					if (!dataResponse.ok) {
-						return {
-							content: [{
-								type: "text",
-								text: `Error: Failed to fetch resource data (HTTP ${dataResponse.status}).`
-							}]
-						};
-					}
-
-					const contentType = dataResponse.headers.get('content-type') || '';
-					const rawData = await dataResponse.text();
-
-					if (format === 'json' || contentType.includes('json')) {
-						const parsed = JSON.parse(rawData);
-						const array = Array.isArray(parsed) ? parsed : [parsed];
-						const records = array.slice(0, maxLimit);
-						const fields = records.length > 0 ? Object.keys(records[0]) : [];
+					if (datastoreData.success && datastoreData.result?.records) {
+						const records = datastoreData.result.records;
+						const fields = datastoreData.result.fields?.map((f: any) => f.id).filter((id: string) => id !== '_id') || [];
 
 						const table = buildTable(fields, records, {
-							source: 'Direct fetch (JSON)',
+							source: 'DataStore',
 							url: resourceUrl,
+							total: datastoreData.result.total,
 							showing: records.length
 						});
 
 						return { content: [{ type: "text", text: table }] };
 					}
+				} catch (datastoreError) {
+					// DataStore failed, continue to fallback
+				}
 
-					if (format === 'csv' || contentType.includes('csv') || resourceUrl.endsWith('.csv')) {
-						const { fields, records } = parseCSV(rawData, maxLimit);
-
-						const table = buildTable(fields, records, {
-							source: 'Direct fetch (CSV)',
-							url: resourceUrl,
-							showing: records.length
-						});
-
-						return { content: [{ type: "text", text: table }] };
-					}
-
+				const dataResponse = await fetch(resourceUrl);
+				if (!dataResponse.ok) {
 					return {
 						content: [{
 							type: "text",
-							text: `Error: Unsupported format '${format}'. Only CSV and JSON are supported.`
-						}]
-					};
-
-				} catch (error) {
-					return {
-						content: [{
-							type: "text",
-							text: `Error: Failed to preview data. ${error instanceof Error ? error.message : 'Unknown error'}`
+							text: `Error: Failed to fetch resource data (HTTP ${dataResponse.status}).`
 						}]
 					};
 				}
+
+				const contentType = dataResponse.headers.get('content-type') || '';
+				const rawData = await dataResponse.text();
+
+				if (format === 'json' || contentType.includes('json')) {
+					const parsed = JSON.parse(rawData);
+					const array = Array.isArray(parsed) ? parsed : [parsed];
+					const records = array.slice(0, maxLimit);
+					const fields = records.length > 0 ? Object.keys(records[0]) : [];
+
+					const table = buildTable(fields, records, {
+						source: 'Direct fetch (JSON)',
+						url: resourceUrl,
+						showing: records.length
+					});
+
+					return { content: [{ type: "text", text: table }] };
+				}
+
+				if (format === 'csv' || contentType.includes('csv') || resourceUrl.endsWith('.csv')) {
+					const { fields, records } = parseCSV(rawData, maxLimit);
+
+					const table = buildTable(fields, records, {
+						source: 'Direct fetch (CSV)',
+						url: resourceUrl,
+						showing: records.length
+					});
+
+					return { content: [{ type: "text", text: table }] };
+				}
+
+				return {
+					content: [{
+						type: "text",
+						text: `Error: Unsupported format '${format}'. Only CSV and JSON are supported.`
+					}]
+				};
+
+			} catch (error) {
+				return {
+					content: [{
+						type: "text",
+						text: `Error: Failed to preview data. ${error instanceof Error ? error.message : 'Unknown error'}`
+					}]
+				};
 			}
-		);
+		}
+	);
+
+	return server;
+}
+
+const agentCache = new Map<string, typeof McpAgent<Env>>();
+
+function getAgentClass(organization?: string): typeof McpAgent<Env> {
+	const cacheKey = organization || "_default";
+
+	if (!agentCache.has(cacheKey)) {
+		const server = createMCPServer(organization);
+		const AgentClass = class extends McpAgent<Env> {
+			server = server;
+			async init() {
+			}
+		};
+		agentCache.set(cacheKey, AgentClass);
+	}
+
+	return agentCache.get(cacheKey)!;
+}
+
+export class MyMCP extends McpAgent<Env> {
+	server = createMCPServer();
+	async init() {
 	}
 }
 
 export default {
 	fetch(request: Request, env: Env, ctx: ExecutionContext) {
 		const url = new URL(request.url);
+		const pathname = url.pathname;
 
-		if (url.pathname === "/sse" || url.pathname === "/sse/message") {
-			return MyMCP.serveSSE("/sse").fetch(request, env, ctx);
+		// Parse organization from URL path
+		// Supports: /@org-name/sse, /@org-name/sse/message, /@org-name/mcp
+		// Also supports: /org-name/sse (without @)
+		const orgMatch = pathname.match(/^\/(@)?([^\/]+)\/(sse|mcp)(\/.*)?$/);
+
+		if (orgMatch) {
+			const [, hasAt, orgName, endpoint, subpath] = orgMatch;
+
+			console.error('[FETCH] Matched org path:', pathname);
+			console.error('[FETCH] Extracted org name:', orgName);
+
+			const AgentClass = getAgentClass(orgName);
+
+			const rewrittenUrl = new URL(request.url);
+			rewrittenUrl.pathname = `/${endpoint}${subpath || ''}`;
+
+			const rewrittenRequest = new Request(rewrittenUrl.toString(), {
+				method: request.method,
+				headers: request.headers,
+				body: request.body,
+				duplex: 'half'
+			});
+
+			if (endpoint === "sse") {
+				return AgentClass.serveSSE("/sse").fetch(rewrittenRequest, env, ctx);
+			}
+
+			if (endpoint === "mcp") {
+				return AgentClass.serve("/mcp").fetch(rewrittenRequest, env, ctx);
+			}
 		}
 
-		if (url.pathname === "/mcp") {
-			return MyMCP.serve("/mcp").fetch(request, env, ctx);
+		// Legacy routes (no organization)
+		if (pathname === "/sse" || pathname === "/sse/message") {
+			const AgentClass = getAgentClass();
+			return AgentClass.serveSSE("/sse").fetch(request, env, ctx);
+		}
+
+		if (pathname === "/mcp") {
+			const AgentClass = getAgentClass();
+			return AgentClass.serve("/mcp").fetch(request, env, ctx);
 		}
 
 		return new Response("Not found", { status: 404 });


### PR DESCRIPTION
Issue in question: https://github.com/datopian/portaljs/issues/1477
---
Implemented changes in the MCP server to allow passing a organization name in the URL path, similar to the API endpoint, so that the MCP only returns results within that specific organization.
---

- The main API URL is dynamic now, depending if the user connector has an organization name such as:
- https://mcp.portaljs.com/sse ( it will work as normal having universal scope )
- https://mcp.portaljs.com/abeelha/sse ( now it will be limited to just have access to _"abeelha"_ organization data

>**NOTE:**
> removed .env since its not necessary _( also needs to remove the URL from the cloudflare worker variable enviroment )_

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Organization-based routing: requests route to org-specific endpoints via path-based routes, including org-scoped realtime (SSE) streams.
  * Router derives org from URL and adjusts endpoint targets accordingly.

* **Bug Fixes**
  * Search includes query parameter only when provided.
  * Clear 404 responses for non-org or unmatched paths.

* **Chores**
  * Removed template entries from the example environment configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->